### PR TITLE
let ccache find earlier in PATH env variable

### DIFF
--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -20,4 +20,4 @@ RUN sed -i.bkp -e \
 USER ubuntu
 WORKDIR /home/ubuntu/
 
-ENV PATH ${PATH}:/usr/lib/ccache
+ENV PATH /usr/lib/ccache:${PATH}


### PR DESCRIPTION
The PATH to ccache executable should be before the PATH of compiler.
i.e., the previous circleci image wasn't using ccache.

Signed-off-by: Hajime Tazaki <thehajime@gmail.com>