### PR TITLE
add clang/lld docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@
 
 TARGETS := circleci circleci-android circleci-android-arm32 \
 	circleci-android-arm64 circleci-mingw circleci-x86_64 \
-	circleci-freebsd11-x86_64
+	circleci-freebsd11-x86_64 \
+	circleci-clang-x86_64 circleci-clang-i386
 
 #
 # To publish a new tag modify the variables below, commit and then
@@ -27,6 +28,8 @@ TAG_circleci-android := 0.5
 TAG_circleci-android-arm32 := 0.6
 TAG_circleci-android-arm64 := 0.6
 TAG_circleci-freebsd11-x86_64 := 0.4
+TAG_circleci-clang-x86_64 := 0.1
+TAG_circleci-clang-i386 := 0.1
 
 all: $(TARGETS)
 
@@ -52,6 +55,12 @@ circleci-freebsd11-x86_64: circleci/freebsd11
 	docker build -t lkldocker/$@:$(TAG_$@) $^
 
 circleci-i386: circleci/i386
+	docker build -t lkldocker/$@:$(TAG_$@) $^
+
+circleci-clang-x86_64: circleci/clang/x86_64
+	docker build -t lkldocker/$@:$(TAG_$@) $^
+
+circleci-clang-i386: circleci/clang/i386
 	docker build -t lkldocker/$@:$(TAG_$@) $^
 
 tag-%:

--- a/circleci/clang/i386/Dockerfile
+++ b/circleci/clang/i386/Dockerfile
@@ -1,0 +1,33 @@
+FROM i386/ubuntu:18.04
+LABEL authors="Hajime Tazaki <thehajime@gmail.com>, Octavian Purdila <tavi@cs.pub.ro>"
+
+ENV LLVM_VERSION=8
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:git-core/ppa && \
+    apt-get update && \
+    apt-get install -y sudo build-essential bc git xfsprogs ccache \
+                       btrfs-tools iputils-ping dosfstools \
+                       python python-pip bison flex iproute2 \
+                       libfuse-dev libarchive-dev \
+                       linux-headers-`uname -r` \
+                       valgrind libnuma-dev \
+                       clang-$LLVM_VERSION lld-$LLVM_VERSION && \
+    ln -sf `which clang-$LLVM_VERSION` /usr/bin/clang && \
+    ln -sf `which ld.lld-$LLVM_VERSION` /usr/bin/ld.lld && \
+    pip install yamlish junit_xml && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN useradd -ms /bin/bash ubuntu && \
+    adduser ubuntu sudo && \
+    echo -n 'ubuntu:ubuntu' | chpasswd
+
+# Enable passwordless sudo for users under the "sudo" group
+RUN sed -i.bkp -e \
+      's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' \
+      /etc/sudoers
+
+USER ubuntu
+WORKDIR /home/ubuntu/
+
+ENV PATH /usr/lib/ccache:${PATH}

--- a/circleci/clang/x86_64/Dockerfile
+++ b/circleci/clang/x86_64/Dockerfile
@@ -1,0 +1,16 @@
+FROM lkldocker/circleci:0.5
+LABEL authors="Hajime Tazaki <thehajime@gmail.com>, Octavian Purdila <tavi@cs.pub.ro>"
+
+ENV LLVM_VERSION=8
+RUN sudo apt-get update && \
+    sudo apt-get install -y wget && \
+    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - && \
+    sudo add-apt-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-$LLVM_VERSION main" && \
+    sudo apt-get update && \
+    sudo apt-get install -y libfuse-dev libarchive-dev \
+                       linux-headers-4.4.0-97-generic \
+                       valgrind libnuma-dev \
+                       clang-$LLVM_VERSION lld-$LLVM_VERSION && \
+    sudo ln -sf `which clang-$LLVM_VERSION` /usr/bin/clang && \
+    sudo ln -sf `which ld.lld-$LLVM_VERSION` /usr/bin/ld.lld && \
+    sudo rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR introduces docker images for clang/lld toolchain. Please refer https://github.com/lkl/linux/pull/478.