### PR TITLE
qemu_x86_64: Use a fixed release for cloud image we use

### DIFF
--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y sudo build-essential bc git xfsprogs ccache btrfs-tools iputils-ping \
                        dosfstools python python-pip bison flex && \
-    pip install yamlish junit_xml && \
+    pip install yamlish==0.18.1 junit_xml==1.9 PyYAML==5.3.1 && \
     rm -rf /var/lib/apt/lists/*
 
 RUN useradd -ms /bin/bash ubuntu && adduser ubuntu sudo && echo -n 'ubuntu:ubuntu' | chpasswd

--- a/circleci/freebsd11/Dockerfile
+++ b/circleci/freebsd11/Dockerfile
@@ -21,8 +21,8 @@ WORKDIR /home/ubuntu/
 RUN wget -q http://www.iijlab.net/~tazaki/outgoing/FreeBSD-11.1-RELEASE-amd64.qcow2.xz && \
     unxz FreeBSD-11.1-RELEASE-amd64.qcow2.xz
 
-RUN wget -q http://fossies.org/linux/privat/sshpass-1.06.tar.gz && \
-    tar xzf sshpass-1.06.tar.gz && cd sshpass-1.06 && ./configure && make
+RUN wget -q http://fossies.org/linux/privat/sshpass-1.09.tar.gz && \
+    tar xzf sshpass-1.09.tar.gz && cd sshpass-1.09 && ./configure && make
 
 ## Note: building LKL code on qemu (w/o kvm) takes almost forever, around 3hrs in circleci.
 ## So we build own cross-build chain for FreeBSD.
@@ -88,11 +88,11 @@ ENV QEMU "qemu-system-x86_64 -m 2048 \
      -netdev user,id=mynet0,hostfwd=tcp:127.0.0.1:7722-:22 \
      -device e1000,netdev=mynet0 -display none -daemonize"
 
-ENV MYSSH "/home/ubuntu/sshpass-1.06/sshpass -p password ssh \
+ENV MYSSH "/home/ubuntu/sshpass-1.09/sshpass -p password ssh \
     -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
     -q root@localhost -p7722"
 
-ENV MYSCP "/home/ubuntu/sshpass-1.06/sshpass -p password scp \
+ENV MYSCP "/home/ubuntu/sshpass-1.09/sshpass -p password scp \
     -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -q"
 
 

--- a/circleci/qemu-x86_64/Dockerfile
+++ b/circleci/qemu-x86_64/Dockerfile
@@ -25,12 +25,13 @@ RUN wget https://download.qemu.org/qemu-5.0.0.tar.xz && \
     cd .. && \
     rm -rf qemu-5.0.0 qemu-5.0.0.tar.xz
 
-RUN wget -q https://cloud-images.ubuntu.com/releases/bionic/release/ubuntu-18.04-server-cloudimg-amd64.img && \
+RUN wget -q http://cloud-images-archive.ubuntu.com/releases/bionic/release-20200807/ubuntu-18.04-server-cloudimg-amd64.img && \
     qemu-img resize ubuntu-18.04-server-cloudimg-amd64.img 10G
 
 RUN dd if=/dev/zero of=nvme.img bs=1024 count=102400
 
 COPY cloud.txt .
+RUN sudo chmod a+r cloud.txt
 RUN cloud-localds cloud.img cloud.txt
 
 ENV QEMU "qemu-system-x86_64 -m 2048 -machine q35,kernel-irqchip=split\

--- a/circleci/qemu-x86_64/Dockerfile
+++ b/circleci/qemu-x86_64/Dockerfile
@@ -13,8 +13,8 @@ RUN sudo cp /boot/initrd.img-4.15.0-112-generic .
 
 RUN sudo chown ubuntu:ubuntu vmlinuz-4.15.0-112-generic initrd.img-4.15.0-112-generic
 
-RUN wget -q http://fossies.org/linux/privat/sshpass-1.06.tar.gz && \
-    tar xzf sshpass-1.06.tar.gz && cd sshpass-1.06 && ./configure && make
+RUN wget -q http://fossies.org/linux/privat/sshpass-1.09.tar.gz && \
+    tar xzf sshpass-1.09.tar.gz && cd sshpass-1.09 && ./configure && make
 
 RUN wget https://download.qemu.org/qemu-5.0.0.tar.xz && \
     tar xf qemu-5.0.0.tar.xz && \
@@ -43,9 +43,9 @@ ENV QEMU "qemu-system-x86_64 -m 2048 -machine q35,kernel-irqchip=split\
      -append 'root=LABEL=cloudimg-rootfs ro intel_iommu=on console=tty1 console=ttyS0'\
      -display none -serial mon:telnet::5555,server,nowait -daemonize"
 
-ENV MYSSH "/home/ubuntu/sshpass-1.06/sshpass -p lkl ssh \
+ENV MYSSH "/home/ubuntu/sshpass-1.09/sshpass -p lkl ssh \
     -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
     -q lkl@localhost -p2222"
 
-ENV MYSCP "/home/ubuntu/sshpass-1.06/sshpass -p lkl scp \
+ENV MYSCP "/home/ubuntu/sshpass-1.09/sshpass -p lkl scp \
     -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -q -P 2222"


### PR DESCRIPTION
The latest could img releases used for qemu-x86_64 are not compatible with the kernel image
we picked (4.15.0-112), used a fixed version to avoid this and future issues.

Also use fixed versions for pip packages to avoid incompatibilities with latest pyaml and python2.

Finally, update to sshpass 1.09, 1.06 is no longer available for download.

