### PR TITLE
Fix android preadv

### DIFF
--- a/circleci/android/arm64/Dockerfile
+++ b/circleci/android/arm64/Dockerfile
@@ -4,7 +4,7 @@ FROM $IMAGE_NAME
 LABEL authors="Hajime Tazaki <thehajime@gmail.com>, Octavian Purdila <tavi@cs.pub.ro>"
 
 # install toolchain from NDK
-RUN ./android-ndk-r15b/build/tools/make_standalone_toolchain.py --arch arm64 --api 23 --install-dir ./aarch64-linux-android && \
+RUN ./android-ndk-r15b/build/tools/make_standalone_toolchain.py --arch arm64 --api 24 --install-dir ./aarch64-linux-android && \
     rm -rf android-ndk-r15b
 
 # update toolchain, see https://github.com/lkl/linux/issues/348#issuecomment-312409409

--- a/circleci/x86_64/Dockerfile
+++ b/circleci/x86_64/Dockerfile
@@ -4,5 +4,5 @@ FROM $IMAGE_NAME
 LABEL authors="Hajime Tazaki <thehajime@gmail.com>, Octavian Purdila <tavi@cs.pub.ro>"
 
 RUN sudo apt-get update && \
-    sudo apt-get install -y libfuse-dev libarchive-dev linux-headers-4.4.0-97-generic valgrind libnuma-dev && \
+    sudo apt-get install -y libfuse-dev libarchive-dev linux-headers-generic valgrind libnuma-dev && \
     sudo rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
https://github.com/lkl/linux/pull/563#issuecomment-2665028658

This also contains a fix to not being able to download old package name for x86_64 build.

Cc: @tavip @ddiss