### PR TITLE
android: use v1.3 image for the base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,14 +41,24 @@ do_steps: &do_steps
   - run:
       name: android arm32 image build
       command: |
+        ## XXX: v1.3 image is the last one which contains the right emulator.
+        ## if we install emulator via sdkmanager, it'll install version 35.3.11.x which isn't able to
+        ## run arm64 image on x86_64 host.
+        ## thus, we stick our old image which has a proper emulator version.
+        ## super dirty, but we may need to overhaul all infrastructure for android build/test.
         if [[ $CIRCLE_NODE_INDEX == 1 ]]; then
-          cd circleci/android/arm32 && docker build --build-arg IMAGE_NAME=lkldocker/circleci-android:$GIT_TAG -t lkldocker/circleci-android-arm32:$GIT_TAG . && cd ../../..
+          cd circleci/android/arm32 && docker build --build-arg IMAGE_NAME=lkldocker/circleci-android:v1.3 -t lkldocker/circleci-android-arm32:$GIT_TAG . && cd ../../..
         fi
   - run:
       name: android arm64 image build
       command: |
+        ## XXX: v1.3 image is the last one which contains the right emulator.
+        ## if we install emulator via sdkmanager, it'll install version 35.3.11.x which isn't able to
+        ## run arm64 image on x86_64 host.
+        ## thus, we stick our old image which has a proper emulator version.
+        ## super dirty, but we may need to overhaul all infrastructure for android build/test.
         if [[ $CIRCLE_NODE_INDEX == 1 ]]; then
-          cd circleci/android/arm64 && docker build --build-arg IMAGE_NAME=lkldocker/circleci-android:$GIT_TAG -t lkldocker/circleci-android-arm64:$GIT_TAG . && cd ../../..
+          cd circleci/android/arm64 && docker build --build-arg IMAGE_NAME=lkldocker/circleci-android:v1.3 -t lkldocker/circleci-android-arm64:$GIT_TAG . && cd ../../..
         fi
   - run:
       name: qemu x86_64 image build


### PR DESCRIPTION
Within a build process of android images, we can no longer install a right emulator which we can test arm64 image on x86_host.  This is because the sdkmanager can install the latest (need confirmation?) version of emulator, and the latest one as of today (2025 Feb.) doesn't allow us to run arm64 image on x86_64 hosts.

Thus we use the previously built image, lkldocker/circleci-android:v1.3, as a base image for android-arm{32,64} images.

We may need to overhaul the build/test infrastructure in future but this is a quick fix which solves the issue we faced.